### PR TITLE
DON'T MERGE YET: Replace deprecated 'localinstall' alias with 'install' for RPM package installation

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -263,7 +263,7 @@ module Unix::Pkg
     when /^(amazon(fips)?|fedora|el|redhat|centos)$/
       command_name = 'yum'
       command_name = 'dnf' if (variant == 'fedora' && version.to_i > 21) || (variant == 'amazon' && version.to_i >= 2023)
-      execute("#{command_name} --nogpgcheck localinstall -y #{onhost_package_file}")
+      execute("#{command_name} --nogpgcheck install -y #{onhost_package_file}")
     when /^(opensuse|sles)$/
       execute("zypper --non-interactive --no-gpg-checks in #{onhost_package_file}")
     when /^(debian|ubuntu)$/


### PR DESCRIPTION
## Description
This PR replaces the usage of the 'localinstall' command with 'install' when installing local packages on RPM-based systems. The 'localinstall' command was an alias that has been removed in dnf 5.x, making our current implementation fail on newer systems like Fedora 41.

## Background
The 'localinstall' command was always just an alias for 'install' that implied the package was local rather than from a repository. In dnf 5.x, several such aliases were removed to simplify the codebase, as documented in the [Fedora forums](https://forums.fedoraforum.org/showthread.php?330839-No-more-groupinstall-with-dnf5).

## Testing
Manual testing confirms this works correctly on:
- Fedora 40 (dnf 4.x)
- Fedora 41 (dnf 5.x)

Since 'install' works for all versions of both dnf and yum, this is a more future-proof approach than maintaining version-specific logic.

## Related Issues
Fixes installation failures on systems with dnf 5.x where the 'localinstall' command is no longer available.